### PR TITLE
Fix description key in GPL License

### DIFF
--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -66,7 +66,7 @@ limitations under the License.
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
-    {{ cookiecutter.project_short_description }}
+    {{ cookiecutter.description }}
     Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author_name }}
 
     This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Fix issue create GPL project
```
Unable to create file 'LICENSE'
Error message: 'dict object' has no attribute 'project_short_description'
```